### PR TITLE
refactor: search params

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -5,16 +5,16 @@ import { WorkSkeletons } from './components/works/skeleton';
 
 import useSWR from 'swr';
 import { motion } from 'framer-motion';
-import { useSearch } from '@tanstack/react-router';
 import { withQuery } from '@asmr-collections/shared';
 
 import { notifyError } from '~/utils';
 import { fetcher } from '~/lib/fetcher';
+import { indexRoute } from './providers/router/route';
 
 import type { WorksResponse } from '@asmr-collections/shared';
 
 export default function App() {
-  const _search = useSearch({ from: '/' });
+  const _search = indexRoute.useSearch();
 
   // 确保 limit 和 page 在最后面，防止 key 变化
   const { page, limit, ...rest } = _search;

--- a/apps/web/src/components/header/go-to-detail.tsx
+++ b/apps/web/src/components/header/go-to-detail.tsx
@@ -1,16 +1,14 @@
 import { useState } from 'react';
-import { getRouteApi } from '@tanstack/react-router';
 
 import { WorkInput } from '../work-input';
 import { ArrowRight } from 'lucide-react';
 
 import { parseWorkInput } from '@asmr-collections/shared';
-
-const route = getRouteApi('/work-details/$id');
+import { workDetailsRoute } from '~/providers/router/route';
 
 export function GoToDetail() {
   const [id, setId] = useState('');
-  const navigate = route.useNavigate();
+  const navigate = workDetailsRoute.useNavigate();
 
   const { validIds, isValid } = parseWorkInput(id);
 

--- a/apps/web/src/components/header/search-bar.tsx
+++ b/apps/web/src/components/header/search-bar.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 
-import { useGenerateSearch } from '~/hooks/use-generate-search';
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '../ui/input-group';
 import { Search, Zap, ZapOff } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -17,16 +16,15 @@ export function SearchBar({ search }: SearchBarProps) {
   const [keyword, setKeyword] = useState(() => search.keyword ?? '');
   const [isEmbedding, setIsEmbedding] = useState(() => !!search.embedding);
 
-  const { exclude } = useGenerateSearch();
   const navigate = useNavigate();
 
   const onSearch = () => {
     if (!keyword.trim()) return;
 
     if (isEmbedding)
-      navigate({ to: '/', search: exclude(['page', 'keyword'], { embedding: keyword }) });
+      navigate({ to: '/', search: { embedding: keyword } });
     else
-      navigate({ to: '/', search: exclude(['page', 'embedding'], { keyword }) });
+      navigate({ to: '/', search: { keyword } });
   };
 
   return (

--- a/apps/web/src/components/header/work-details-menu/index.tsx
+++ b/apps/web/src/components/header/work-details-menu/index.tsx
@@ -1,7 +1,5 @@
 import { Suspense, useState } from 'react';
 
-import { getRouteApi } from '@tanstack/react-router';
-
 import { Button } from '~/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuTrigger } from '~/components/ui/dropdown-menu';
 
@@ -12,7 +10,9 @@ import { GoToDetail } from '../go-to-detail';
 import { HiddenImage } from '../hidden-image';
 import { ThemeToggle } from '../theme-toggle';
 
-const { useParams, useNavigate } = getRouteApi('/work-details/$id');
+import { workDetailsRoute } from '~/providers/router/route';
+
+const { useParams, useNavigate } = workDetailsRoute;
 
 export function WorkDetailsMenu() {
   const { id } = useParams();

--- a/apps/web/src/components/work-card/badge-menu.tsx
+++ b/apps/web/src/components/work-card/badge-menu.tsx
@@ -11,16 +11,15 @@ import { MetaButton } from '../meta-button';
 import { useState } from 'react';
 
 import { externalUrl, writeClipboard } from '~/utils';
-import type { RootSearchParams } from '~/providers/router';
 
 interface Props {
-  search: RootSearchParams
   metaType: 'artists' | 'illustrators'
+  metaId: number
   text: string
   isFilter?: boolean
 }
 
-export function BadgeMenu({ search, metaType, text, isFilter }: Props) {
+export function BadgeMenu({ metaType, metaId, text, isFilter }: Props) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -32,7 +31,21 @@ export function BadgeMenu({ search, metaType, text, isFilter }: Props) {
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-40" onInteractOutside={() => setOpen(false)}>
         <DropdownMenuItem asChild>
-          <Link disabled={isFilter} to="/" search={search} onClick={() => setOpen(false)}>筛选</Link>
+          <Link
+            disabled={isFilter}
+            to="/"
+            search={p => {
+              const { page, keyword, ...rest } = p;
+              return {
+                ...rest,
+                artistId: metaType === 'artists' ? [metaId] : p.artistId,
+                illustratorId: metaType === 'illustrators' ? metaId : p.illustratorId
+              };
+            }}
+            onClick={() => setOpen(false)}
+          >
+            筛选
+          </Link>
         </DropdownMenuItem>
         <DropdownMenuItem
           className="cursor-pointer"

--- a/apps/web/src/components/work-card/badge-menu.tsx
+++ b/apps/web/src/components/work-card/badge-menu.tsx
@@ -22,6 +22,11 @@ interface Props {
 export function BadgeMenu({ metaType, metaId, text, isFilter }: Props) {
   const [open, setOpen] = useState(false);
 
+  const search = {
+    artists: { artistId: [metaId] },
+    illustrators: { illustratorId: metaId }
+  }[metaType];
+
   return (
     <DropdownMenu open={open} key={String(open) /** 筛选只是添加了 url search，虽然有设置 open false，但是没用 */}>
       <DropdownMenuTrigger asChild>
@@ -30,18 +35,10 @@ export function BadgeMenu({ metaType, metaId, text, isFilter }: Props) {
         </MetaButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-40" onInteractOutside={() => setOpen(false)}>
-        <DropdownMenuItem asChild>
+        <DropdownMenuItem asChild disabled={isFilter}>
           <Link
-            disabled={isFilter}
             to="/"
-            search={p => {
-              const { page, keyword, ...rest } = p;
-              return {
-                ...rest,
-                artistId: metaType === 'artists' ? [metaId] : p.artistId,
-                illustratorId: metaType === 'illustrators' ? metaId : p.illustratorId
-              };
-            }}
+            search={search}
             onClick={() => setOpen(false)}
           >
             筛选

--- a/apps/web/src/components/work-card/genres-popover.tsx
+++ b/apps/web/src/components/work-card/genres-popover.tsx
@@ -19,9 +19,6 @@ interface Props {
 export function GenresPopover({ genres, searchGenres }: Props) {
   const [selectedGenres, setSelectedGenres] = useState(searchGenres ?? []);
 
-  // 路由更新后，弹出框不受影响啊，只改了 search
-  const [forceClose, setForceClose] = useState<number>();
-
   const handleSelect = (id: number) => {
     setSelectedGenres(p => {
       const currentList = p;
@@ -54,7 +51,7 @@ export function GenresPopover({ genres, searchGenres }: Props) {
   };
 
   return (
-    <Popover key={forceClose}>
+    <Popover>
       <PopoverTrigger asChild>
         <Button variant="outline" size="lg" className="flex-1">查看标签</Button>
       </PopoverTrigger>
@@ -93,8 +90,7 @@ export function GenresPopover({ genres, searchGenres }: Props) {
         <Button variant="outline" className="w-full" asChild>
           <Link
             to="/"
-            search={prev => ({ ...prev, genres: selectedGenres, page: undefined, keyword: undefined })}
-            onClick={() => setForceClose(Math.random())}
+            search={{ genres: selectedGenres }}
           >
             筛选
           </Link>

--- a/apps/web/src/components/work-card/index.tsx
+++ b/apps/web/src/components/work-card/index.tsx
@@ -35,7 +35,7 @@ interface Props {
 export function WorkCard({ work, showMenus = true, showImageBadge = true }: Props) {
   const options = useAtomValue(storageOptionsAtom);
 
-  const { search, exclude, include } = useGenerateSearch();
+  const { search, include } = useGenerateSearch();
 
   const existsApi = options.showMissingTags && showImageBadge
     ? `/api/library/exists/${work.id}`
@@ -143,7 +143,7 @@ export function WorkCard({ work, showMenus = true, showImageBadge = true }: Prop
               key={artist.id}
               text={artist.name}
               metaType="artists"
-              search={exclude(['page', 'keyword'], { artistId: [artist.id] })}
+              metaId={artist.id}
               isFilter={search.artistId?.includes(artist.id)}
             />
           ))}
@@ -152,7 +152,7 @@ export function WorkCard({ work, showMenus = true, showImageBadge = true }: Prop
               key={illustrator.id}
               text={illustrator.name}
               metaType="illustrators"
-              search={exclude(['page', 'keyword'], { illustratorId: illustrator.id })}
+              metaId={illustrator.id}
               isFilter={search.illustratorId === illustrator.id}
             />
           ))}

--- a/apps/web/src/hooks/use-generate-search.ts
+++ b/apps/web/src/hooks/use-generate-search.ts
@@ -14,10 +14,10 @@ type FullSearchParams = UnionToIntersection<
   RouterById[RouteIds]['types']['fullSearchSchema']
 >;
 
-export function useGenerateSearch<TFrom extends RouteIds = '/'>(from?: TFrom) {
-  const search = useSearch<RegisteredRouter, TFrom>({ from: from ?? '/' });
+export function useGenerateSearch<TFrom extends RouteIds = '/app'>(from?: TFrom) {
+  const search = useSearch<RegisteredRouter, TFrom>({ from: from ?? '/app' });
 
-  type SearchParams = TFrom extends '/'
+  type SearchParams = TFrom extends '__root__'
     ? FullSearchParams
     : RouterById[TFrom]['types']['fullSearchSchema'];
 

--- a/apps/web/src/hooks/use-generate-search.ts
+++ b/apps/web/src/hooks/use-generate-search.ts
@@ -14,10 +14,10 @@ type FullSearchParams = UnionToIntersection<
   RouterById[RouteIds]['types']['fullSearchSchema']
 >;
 
-export function useGenerateSearch<TFrom extends RouteIds = '__root__'>(from?: TFrom) {
-  const search = useSearch<RegisteredRouter, TFrom>({ from: from ?? '__root__' });
+export function useGenerateSearch<TFrom extends RouteIds = '/index-layout'>(from?: TFrom) {
+  const search = useSearch<RegisteredRouter, TFrom>({ from: from ?? '/index-layout' });
 
-  type SearchParams = TFrom extends '__root__'
+  type SearchParams = TFrom extends '/index-layout'
     ? FullSearchParams
     : RouterById[TFrom]['types']['fullSearchSchema'];
 
@@ -54,7 +54,8 @@ export function useGenerateSearch<TFrom extends RouteIds = '__root__'>(from?: TF
 
       // 从当前搜索参数中提取指定的参数
       for (const key of params) {
-        const searchKey = key as keyof typeof search;
+        const searchKey = key;
+        // @ts-expect-error - is safe because we are checking the key existence in the search object
         if (search[searchKey] === undefined) continue;
         result[key as string] = search[searchKey];
       }

--- a/apps/web/src/hooks/use-generate-search.ts
+++ b/apps/web/src/hooks/use-generate-search.ts
@@ -14,10 +14,10 @@ type FullSearchParams = UnionToIntersection<
   RouterById[RouteIds]['types']['fullSearchSchema']
 >;
 
-export function useGenerateSearch<TFrom extends RouteIds = '/index-layout'>(from?: TFrom) {
-  const search = useSearch<RegisteredRouter, TFrom>({ from: from ?? '/index-layout' });
+export function useGenerateSearch<TFrom extends RouteIds = '/'>(from?: TFrom) {
+  const search = useSearch<RegisteredRouter, TFrom>({ from: from ?? '/' });
 
-  type SearchParams = TFrom extends '/index-layout'
+  type SearchParams = TFrom extends '/'
     ? FullSearchParams
     : RouterById[TFrom]['types']['fullSearchSchema'];
 

--- a/apps/web/src/pages/playback/index.tsx
+++ b/apps/web/src/pages/playback/index.tsx
@@ -77,7 +77,7 @@ function PlaybackSuspense() {
   );
 }
 
-const Route = createLazyRoute('/index-layout/playback')({
+const Route = createLazyRoute('/playback')({
   component: PlaybackSuspense
 });
 

--- a/apps/web/src/pages/playback/index.tsx
+++ b/apps/web/src/pages/playback/index.tsx
@@ -77,7 +77,7 @@ function PlaybackSuspense() {
   );
 }
 
-const Route = createLazyRoute('/playback')({
+const Route = createLazyRoute('/app/playback')({
   component: PlaybackSuspense
 });
 

--- a/apps/web/src/pages/playback/index.tsx
+++ b/apps/web/src/pages/playback/index.tsx
@@ -1,7 +1,7 @@
 import useSWR from 'swr';
 import { Suspense } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { createLazyRoute, useSearch } from '@tanstack/react-router';
+import { createLazyRoute } from '@tanstack/react-router';
 
 import { ItemGroup } from '~/components/ui/item';
 
@@ -14,11 +14,12 @@ import { notifyError } from '~/utils';
 import { withQuery } from '@asmr-collections/shared';
 
 import { fetcher } from '~/lib/fetcher';
+import { playbackRoute } from '~/providers/router/route';
 
 import type { PlaybacksResponse } from '@asmr-collections/shared';
 
 function Playback() {
-  const search = useSearch({ from: '/playback' });
+  const search = playbackRoute.useSearch();
 
   const swrKey = withQuery('/api/playback', {
     page: search.page,
@@ -76,7 +77,7 @@ function PlaybackSuspense() {
   );
 }
 
-const Route = createLazyRoute('/playback')({
+const Route = createLazyRoute('/index-layout/playback')({
   component: PlaybackSuspense
 });
 

--- a/apps/web/src/pages/playlists/index.tsx
+++ b/apps/web/src/pages/playlists/index.tsx
@@ -8,17 +8,18 @@ import { PlaylistDialog } from './components/playlist-dialog';
 import useSWR from 'swr';
 import { Suspense } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { createLazyRoute, useSearch } from '@tanstack/react-router';
+import { createLazyRoute } from '@tanstack/react-router';
 
 import { notifyError } from '~/utils';
 import { fetcher } from '~/lib/fetcher';
+import { playlistsRoute } from '~/providers/router/route';
 
 import { withQuery } from '@asmr-collections/shared';
 
 import type { PlaylistsResponse } from '@asmr-collections/shared';
 
 function Playlists() {
-  const search = useSearch({ from: '/playlists' });
+  const search = playlistsRoute.useSearch();
 
   const swrKey = withQuery('/api/playlist', {
     page: search.page,
@@ -79,7 +80,7 @@ function PlaylistsWrapper() {
   );
 }
 
-const Route = createLazyRoute('/playlists')({
+const Route = createLazyRoute('/index-layout/playlists')({
   component: PlaylistsWrapper
 });
 

--- a/apps/web/src/pages/playlists/index.tsx
+++ b/apps/web/src/pages/playlists/index.tsx
@@ -80,7 +80,7 @@ function PlaylistsWrapper() {
   );
 }
 
-const Route = createLazyRoute('/playlists')({
+const Route = createLazyRoute('/app/playlists')({
   component: PlaylistsWrapper
 });
 

--- a/apps/web/src/pages/playlists/index.tsx
+++ b/apps/web/src/pages/playlists/index.tsx
@@ -80,7 +80,7 @@ function PlaylistsWrapper() {
   );
 }
 
-const Route = createLazyRoute('/index-layout/playlists')({
+const Route = createLazyRoute('/playlists')({
   component: PlaylistsWrapper
 });
 

--- a/apps/web/src/pages/playlists/playlist/index.tsx
+++ b/apps/web/src/pages/playlists/playlist/index.tsx
@@ -84,7 +84,7 @@ function PlaylistWrapper() {
   );
 }
 
-const Route = createLazyRoute('/index-layout/playlists/$id')({
+const Route = createLazyRoute('/playlists/$id')({
   component: PlaylistWrapper
 });
 

--- a/apps/web/src/pages/playlists/playlist/index.tsx
+++ b/apps/web/src/pages/playlists/playlist/index.tsx
@@ -11,15 +11,16 @@ import { PlaylistDelete } from '../components/playlist-delete';
 import useSWR from 'swr';
 import { Suspense } from 'react';
 import { motion } from 'framer-motion';
-import { createLazyRoute, getRouteApi } from '@tanstack/react-router';
+import { createLazyRoute } from '@tanstack/react-router';
 
 import { notifyError } from '~/utils';
 import { fetcher } from '~/lib/fetcher';
 import { withQuery } from '@asmr-collections/shared';
+import { playlistRoute } from '~/providers/router/route';
 
 import type { PlaylistResponse } from '@asmr-collections/shared';
 
-const { useSearch, useParams } = getRouteApi('/playlists/$id');
+const { useSearch, useParams } = playlistRoute;
 
 function Playlist() {
   const { id } = useParams();
@@ -83,7 +84,7 @@ function PlaylistWrapper() {
   );
 }
 
-const Route = createLazyRoute('/playlists/$id')({
+const Route = createLazyRoute('/index-layout/playlists/$id')({
   component: PlaylistWrapper
 });
 

--- a/apps/web/src/pages/playlists/playlist/index.tsx
+++ b/apps/web/src/pages/playlists/playlist/index.tsx
@@ -84,7 +84,7 @@ function PlaylistWrapper() {
   );
 }
 
-const Route = createLazyRoute('/playlists/$id')({
+const Route = createLazyRoute('/app/playlists/$id')({
   component: PlaylistWrapper
 });
 

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -173,7 +173,7 @@ function Settings() {
   );
 }
 
-const Route = createLazyRoute('/index-layout/settings')({
+const Route = createLazyRoute('/settings')({
   component: Settings
 });
 

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -173,7 +173,7 @@ function Settings() {
   );
 }
 
-const Route = createLazyRoute('/settings')({
+const Route = createLazyRoute('/app/settings')({
   component: Settings
 });
 

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -173,7 +173,7 @@ function Settings() {
   );
 }
 
-const Route = createLazyRoute('/settings')({
+const Route = createLazyRoute('/index-layout/settings')({
   component: Settings
 });
 

--- a/apps/web/src/pages/work-details/components/similar.tsx
+++ b/apps/web/src/pages/work-details/components/similar.tsx
@@ -1,4 +1,9 @@
-import { WorkCard } from '~/components/work-card';
+import { Link } from '~/components/link';
+import { Image } from '~/components/image';
+import { Separator } from '~/components/ui/separator';
+import { MetaButton } from '~/components/meta-button';
+import { Card, CardTitle } from '~/components/ui/card';
+import { GenresPopover } from '~/components/work-card/genres-popover';
 import { Carousel, CarouselContent, CarouselItem } from '~/components/ui/carousel';
 
 import { memo, useRef } from 'react';
@@ -7,6 +12,7 @@ import { useSimilar } from '~/hooks/use-similar';
 import Autoplay from 'embla-carousel-autoplay';
 
 import { cn } from '~/lib/utils';
+import { formatISODate } from '@asmr-collections/shared';
 
 import type { Work } from '@asmr-collections/shared';
 
@@ -46,7 +52,90 @@ export const SimilarWorks = memo(({ work, exists }: SimilarWorksProps) => {
                 )}
                 key={similarWork.id}
               >
-                <WorkCard work={similarWork} showMenus={false} showImageBadge={false} />
+                <Card className="bg-zinc-100 dark:bg-zinc-900 overflow-hidden grid grid-rows-[auto_auto_1fr] h-full py-0 gap-2">
+                  <div className="pb-[65%] relative">
+                    <Link to="/work-details/$id" params={{ id: work.id }} title={work.name}>
+                      <Image
+                        src={work.cover}
+                        alt={work.name}
+                        classNames={{
+                          wrapper: 'absolute inset-0'
+                        }}
+                      />
+                    </Link>
+                    <div
+                      className={cn(
+                        'block p-2 py-1 absolute bottom-0 right-0 bg-zinc-800/80 rounded-none rounded-tl-md text-sm',
+                        'text-gray-300 max-w-[70%] truncate'
+                      )}
+                    >
+                      {formatISODate(work.releaseDate)}
+                    </div>
+                    {work.seriesId
+                      ? (
+                        <Link
+                          className={cn(
+                            'block p-2 py-1 absolute bottom-0 left-0 bg-zinc-800/80 rounded-none rounded-tr-md text-sm',
+                            'text-gray-300 max-w-[60%] truncate'
+                          )}
+                          to="/"
+                          search={{ seriesId: work.seriesId }}
+                          underline="hover"
+                        >
+                          {work.series?.name}
+                        </Link>
+                      )
+                      : null}
+                  </div>
+                  <div className="px-2 flex flex-col gap-2">
+                    <CardTitle className="line-clamp-2 leading-6 mb-2 min-h-12">
+                      <Link to="/work-details/$id" params={{ id: work.id }} title={work.name}>
+                        {work.name}
+                      </Link>
+                    </CardTitle>
+                    <Link
+                      className="text-muted-foreground max-w-max"
+                      to="/"
+                      search={{ circleId: work.circleId }}
+                      underline="hover"
+                    >
+                      {work.circle.name}
+                    </Link>
+                    <Separator className="dark:bg-zinc-700" />
+                  </div>
+                  <div className="space-y-2 flex flex-col px-2 pb-6">
+                    <div className="flex-1 max-h-15">
+                      <div className="line-clamp-3 text-sm opacity-80">{work.intro}</div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {work.artists.map(artist => (
+                        <MetaButton
+                          key={artist.id}
+                          onPointerDown={e => e.preventDefault()}
+                          metaType="artists"
+                          size="sm"
+                          asChild
+                        >
+                          <Link to="/" search={{ artistId: [artist.id] }}>{artist.name}</Link>
+                        </MetaButton>
+                      ))}
+                      {work.illustrators.map(illustrator => (
+                        <MetaButton
+                          key={illustrator.id}
+                          onPointerDown={e => e.preventDefault()}
+                          metaType="illustrators"
+                          size="sm"
+                          asChild
+                        >
+                          <Link to="/" search={{ illustratorId: illustrator.id }}>{illustrator.name}</Link>
+                        </MetaButton>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex p-6 pt-0 px-2 pb-2 gap-2 items-end w-full">
+                    <GenresPopover genres={work.genres} searchGenres={[]} />
+                  </div>
+                </Card>
               </CarouselItem>
             ))
           }

--- a/apps/web/src/pages/work-details/index.tsx
+++ b/apps/web/src/pages/work-details/index.tsx
@@ -1,4 +1,4 @@
-import { createLazyRoute, getRouteApi, useMatchRoute } from '@tanstack/react-router';
+import { createLazyRoute, useMatchRoute } from '@tanstack/react-router';
 
 import { motion } from 'framer-motion';
 import { Activity, Suspense, useCallback } from 'react';
@@ -33,12 +33,13 @@ import { settingOptionsAtom } from '~/hooks/use-setting-options';
 import { externalUrl, writeClipboard } from '~/utils';
 
 import { cn } from '~/lib/utils';
+import { workDetailsRoute } from '~/providers/router/route';
 
-const route = getRouteApi('/work-details/$id');
+const { useNavigate, useSearch, useParams } = workDetailsRoute;
 
 function WorkDetails({ id}: { id: string }) {
-  const navigate = route.useNavigate();
-  const searchPath = route.useSearch({ select: ({ path }) => path });
+  const navigate = useNavigate();
+  const searchPath = useSearch({ select: ({ path }) => path });
   const matchRoute = useMatchRoute();
 
   const settings = useAtomValue(settingOptionsAtom);
@@ -266,7 +267,7 @@ function WorkDetails({ id}: { id: string }) {
 }
 
 function WorkDetailsWrapper() {
-  const { id } = route.useParams();
+  const { id } = useParams();
 
   return (
     <ErrorBoundary key={id}>

--- a/apps/web/src/pages/work-details/index.tsx
+++ b/apps/web/src/pages/work-details/index.tsx
@@ -37,7 +37,7 @@ import { workDetailsRoute } from '~/providers/router/route';
 
 const { useNavigate, useSearch, useParams } = workDetailsRoute;
 
-function WorkDetails({ id}: { id: string }) {
+function WorkDetails({ id }: { id: string }) {
   const navigate = useNavigate();
   const searchPath = useSearch({ select: ({ path }) => path });
   const matchRoute = useMatchRoute();

--- a/apps/web/src/providers/router/index.tsx
+++ b/apps/web/src/providers/router/index.tsx
@@ -2,116 +2,55 @@ import {
   RouterProvider as TanstackRouter,
   Outlet,
   createRootRoute,
-  createRoute,
-  createRouter,
-  stripSearchParams
+  createRouter
 } from '@tanstack/react-router';
 import type { InferFullSearchSchema } from '@tanstack/react-router';
 
+import { z } from 'zod';
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
 
-import App from '~/app';
 import RootLayout from '~/layout';
+
+import {
+  indexLayoutRoute,
+  indexRoute,
+  workDetailsRoute,
+  settingsRoute,
+  playbackRoute,
+  playlistsRoute,
+  playlistRoute
+} from './route';
 
 import { NotFound } from '~/components/not-found';
 
-import { preloadWorkDetails } from './preload';
-import { RootSearchSchema, IndexSearchSchema, PlaybackSearchSchema, WorkDetailsSearchSchema, PlaylistSearchSchema } from './schemas';
-
-import { createRandomSeed } from '~/utils';
-
-import { INDEX_DEFAULT_SEARCH_VALUES, ROOT_DEFAULT_SEARCH_VALUES } from '@asmr-collections/shared';
-
 export type RootSearchParams = InferFullSearchSchema<typeof rootRoute>;
 
-const rootRoute = createRootRoute({
+// eslint-disable-next-line react-refresh/only-export-components -- router
+export const rootRoute = createRootRoute({
   component: () => (
     <RootLayout>
       <Outlet />
       <TanStackRouterDevtools position="bottom-right" />
     </RootLayout>
   ),
-  validateSearch: RootSearchSchema,
-  search: {
-    middlewares: [stripSearchParams(ROOT_DEFAULT_SEARCH_VALUES)]
-  }
+  validateSearch: z.object({
+    keyword: z.string().optional(),
+    embedding: z.string().optional()
+  })
 });
 
 export type IndexSearchParams = InferFullSearchSchema<typeof indexRoute>;
 
-const indexRoute = createRoute({
-  validateSearch: IndexSearchSchema,
-  getParentRoute: () => rootRoute,
-  path: '/',
-  search: {
-    middlewares: [
-      stripSearchParams(INDEX_DEFAULT_SEARCH_VALUES),
-      ({ search, next }) => {
-        const result = next(search);
-
-        if (result.sort === 'random' && !result.seed)
-          return { ...result, seed: createRandomSeed() };
-
-        return result;
-      }
-    ]
-  },
-  component: () => <App />
-});
-
-export type WorkDetailsSearchParams = InferFullSearchSchema<typeof workDetailsRoute>;
-
-const workDetailsRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: '/work-details/$id',
-  staleTime: Infinity,
-  loader({ params, cause }) {
-    const id = params.id;
-    preloadWorkDetails(id, cause);
-  },
-  validateSearch: WorkDetailsSearchSchema
-}).lazy(() => import('~/pages/work-details').then(d => d.default));
-
-const SettingsRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: '/settings'
-}).lazy(() => import('~/pages/settings').then(d => d.default));
-
-const PlaybackRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: '/playback',
-  validateSearch: PlaybackSearchSchema,
-  search: {
-    middlewares: [stripSearchParams(INDEX_DEFAULT_SEARCH_VALUES)]
-  }
-}).lazy(() => import('~/pages/playback').then(d => d.default));
-
-const PlaylistsRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: '/playlists',
-  validateSearch: PlaylistSearchSchema,
-  search: {
-    middlewares: [stripSearchParams(INDEX_DEFAULT_SEARCH_VALUES)]
-  }
-}).lazy(() => import('~/pages/playlists').then(d => d.default));
-
-const PlaylistRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: '/playlists/$id',
-  validateSearch: PlaylistSearchSchema,
-  search: {
-    middlewares: [stripSearchParams(INDEX_DEFAULT_SEARCH_VALUES)]
-  }
-}).lazy(() => import('~/pages/playlists/playlist').then(d => d.default));
-
 const router = createRouter({
   routeTree: rootRoute.addChildren([
-    indexRoute,
-    workDetailsRoute,
-    SettingsRoute,
-    PlaybackRoute,
-    PlaylistsRoute,
-    PlaylistRoute
+    indexLayoutRoute.addChildren([
+      indexRoute,
+      settingsRoute,
+      playbackRoute,
+      playlistsRoute,
+      playlistRoute
+    ]),
+    workDetailsRoute
   ]),
   defaultNotFoundComponent: NotFound,
   defaultPreload: 'intent',

--- a/apps/web/src/providers/router/index.tsx
+++ b/apps/web/src/providers/router/index.tsx
@@ -12,6 +12,7 @@ import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
 import RootLayout from '~/layout';
 
 import {
+  appRoute,
   indexRoute,
   workDetailsRoute,
   settingsRoute,
@@ -42,7 +43,8 @@ export type IndexSearchParams = InferFullSearchSchema<typeof indexRoute>;
 
 const router = createRouter({
   routeTree: rootRoute.addChildren([
-    indexRoute.addChildren([
+    appRoute.addChildren([
+      indexRoute,
       settingsRoute,
       playbackRoute,
       playlistsRoute,

--- a/apps/web/src/providers/router/index.tsx
+++ b/apps/web/src/providers/router/index.tsx
@@ -23,8 +23,6 @@ import {
 
 import { NotFound } from '~/components/not-found';
 
-export type RootSearchParams = InferFullSearchSchema<typeof rootRoute>;
-
 // eslint-disable-next-line react-refresh/only-export-components -- router
 export const rootRoute = createRootRoute({
   component: () => (

--- a/apps/web/src/providers/router/index.tsx
+++ b/apps/web/src/providers/router/index.tsx
@@ -12,7 +12,6 @@ import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
 import RootLayout from '~/layout';
 
 import {
-  indexLayoutRoute,
   indexRoute,
   workDetailsRoute,
   settingsRoute,
@@ -43,8 +42,7 @@ export type IndexSearchParams = InferFullSearchSchema<typeof indexRoute>;
 
 const router = createRouter({
   routeTree: rootRoute.addChildren([
-    indexLayoutRoute.addChildren([
-      indexRoute,
+    indexRoute.addChildren([
       settingsRoute,
       playbackRoute,
       playlistsRoute,

--- a/apps/web/src/providers/router/route.tsx
+++ b/apps/web/src/providers/router/route.tsx
@@ -15,10 +15,10 @@ import { createRandomSeed } from '~/utils';
 
 import { INDEX_DEFAULT_SEARCH_VALUES, ROOT_DEFAULT_SEARCH_VALUES } from '@asmr-collections/shared';
 
-export const indexLayoutRoute = createRoute({
+export const indexRoute = createRoute({
   validateSearch: IndexSearchSchema.extend(RootSearchSchema.shape),
   getParentRoute: () => rootRoute,
-  id: 'index-layout',
+  path: '/',
   search: {
     middlewares: [
       stripSearchParams({ ...ROOT_DEFAULT_SEARCH_VALUES, ...INDEX_DEFAULT_SEARCH_VALUES }),
@@ -34,13 +34,7 @@ export const indexLayoutRoute = createRoute({
         return result;
       }
     ]
-  }
-});
-
-export const indexRoute = createRoute({
-  getParentRoute: () => indexLayoutRoute,
-  path: '/',
-  validateSearch: IndexSearchSchema,
+  },
   component: () => <App />
 });
 
@@ -58,24 +52,24 @@ export const workDetailsRoute = createRoute({
 }).lazy(() => import('~/pages/work-details').then(d => d.default));
 
 export const settingsRoute = createRoute({
-  getParentRoute: () => indexLayoutRoute,
+  getParentRoute: () => indexRoute,
   path: '/settings'
 }).lazy(() => import('~/pages/settings').then(d => d.default));
 
 export const playbackRoute = createRoute({
-  getParentRoute: () => indexLayoutRoute,
+  getParentRoute: () => indexRoute,
   path: '/playback',
   validateSearch: PlaybackSearchSchema
 }).lazy(() => import('~/pages/playback').then(d => d.default));
 
 export const playlistsRoute = createRoute({
-  getParentRoute: () => indexLayoutRoute,
+  getParentRoute: () => indexRoute,
   path: '/playlists',
   validateSearch: PlaylistSearchSchema
 }).lazy(() => import('~/pages/playlists').then(d => d.default));
 
 export const playlistRoute = createRoute({
-  getParentRoute: () => indexLayoutRoute,
+  getParentRoute: () => indexRoute,
   path: '/playlists/$id',
   validateSearch: PlaylistSearchSchema
 }).lazy(() => import('~/pages/playlists/playlist').then(d => d.default));

--- a/apps/web/src/providers/router/route.tsx
+++ b/apps/web/src/providers/router/route.tsx
@@ -15,10 +15,10 @@ import { createRandomSeed } from '~/utils';
 
 import { INDEX_DEFAULT_SEARCH_VALUES, ROOT_DEFAULT_SEARCH_VALUES } from '@asmr-collections/shared';
 
-export const indexRoute = createRoute({
+export const appRoute = createRoute({
+  id: 'app',
   validateSearch: IndexSearchSchema.extend(RootSearchSchema.shape),
   getParentRoute: () => rootRoute,
-  path: '/',
   search: {
     middlewares: [
       stripSearchParams({ ...ROOT_DEFAULT_SEARCH_VALUES, ...INDEX_DEFAULT_SEARCH_VALUES }),
@@ -34,7 +34,12 @@ export const indexRoute = createRoute({
         return result;
       }
     ]
-  },
+  }
+});
+
+export const indexRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: '/',
   component: () => <App />
 });
 
@@ -52,24 +57,24 @@ export const workDetailsRoute = createRoute({
 }).lazy(() => import('~/pages/work-details').then(d => d.default));
 
 export const settingsRoute = createRoute({
-  getParentRoute: () => indexRoute,
+  getParentRoute: () => appRoute,
   path: '/settings'
 }).lazy(() => import('~/pages/settings').then(d => d.default));
 
 export const playbackRoute = createRoute({
-  getParentRoute: () => indexRoute,
+  getParentRoute: () => appRoute,
   path: '/playback',
   validateSearch: PlaybackSearchSchema
 }).lazy(() => import('~/pages/playback').then(d => d.default));
 
 export const playlistsRoute = createRoute({
-  getParentRoute: () => indexRoute,
+  getParentRoute: () => appRoute,
   path: '/playlists',
   validateSearch: PlaylistSearchSchema
 }).lazy(() => import('~/pages/playlists').then(d => d.default));
 
 export const playlistRoute = createRoute({
-  getParentRoute: () => indexRoute,
+  getParentRoute: () => appRoute,
   path: '/playlists/$id',
   validateSearch: PlaylistSearchSchema
 }).lazy(() => import('~/pages/playlists/playlist').then(d => d.default));

--- a/apps/web/src/providers/router/route.tsx
+++ b/apps/web/src/providers/router/route.tsx
@@ -1,0 +1,81 @@
+import {
+  createRoute,
+  stripSearchParams
+} from '@tanstack/react-router';
+import type { InferFullSearchSchema } from '@tanstack/react-router';
+
+import App from '~/app';
+
+import { rootRoute } from '.';
+
+import { preloadWorkDetails } from './preload';
+import { RootSearchSchema, IndexSearchSchema, PlaybackSearchSchema, WorkDetailsSearchSchema, PlaylistSearchSchema } from './schemas';
+
+import { createRandomSeed } from '~/utils';
+
+import { INDEX_DEFAULT_SEARCH_VALUES, ROOT_DEFAULT_SEARCH_VALUES } from '@asmr-collections/shared';
+
+export const indexLayoutRoute = createRoute({
+  validateSearch: IndexSearchSchema.extend(RootSearchSchema.shape),
+  getParentRoute: () => rootRoute,
+  id: 'index-layout',
+  search: {
+    middlewares: [
+      stripSearchParams({ ...ROOT_DEFAULT_SEARCH_VALUES, ...INDEX_DEFAULT_SEARCH_VALUES }),
+      ({ search, next }) => {
+        const result = next(search);
+
+        if (result.sort === 'random' && !result.seed)
+          return { ...result, seed: createRandomSeed() };
+
+        if (result.sort !== 'random' && result.seed)
+          return { ...result, seed: undefined };
+
+        return result;
+      }
+    ]
+  }
+});
+
+export const indexRoute = createRoute({
+  getParentRoute: () => indexLayoutRoute,
+  path: '/',
+  validateSearch: IndexSearchSchema,
+  component: () => <App />
+});
+
+export type WorkDetailsSearchParams = InferFullSearchSchema<typeof workDetailsRoute>;
+
+export const workDetailsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/work-details/$id',
+  staleTime: Infinity,
+  loader({ params, cause }) {
+    const id = params.id;
+    preloadWorkDetails(id, cause);
+  },
+  validateSearch: WorkDetailsSearchSchema
+}).lazy(() => import('~/pages/work-details').then(d => d.default));
+
+export const settingsRoute = createRoute({
+  getParentRoute: () => indexLayoutRoute,
+  path: '/settings'
+}).lazy(() => import('~/pages/settings').then(d => d.default));
+
+export const playbackRoute = createRoute({
+  getParentRoute: () => indexLayoutRoute,
+  path: '/playback',
+  validateSearch: PlaybackSearchSchema
+}).lazy(() => import('~/pages/playback').then(d => d.default));
+
+export const playlistsRoute = createRoute({
+  getParentRoute: () => indexLayoutRoute,
+  path: '/playlists',
+  validateSearch: PlaylistSearchSchema
+}).lazy(() => import('~/pages/playlists').then(d => d.default));
+
+export const playlistRoute = createRoute({
+  getParentRoute: () => indexLayoutRoute,
+  path: '/playlists/$id',
+  validateSearch: PlaylistSearchSchema
+}).lazy(() => import('~/pages/playlists/playlist').then(d => d.default));


### PR DESCRIPTION
重构了的 search params 的生效路由，原先将所有筛选所需的 sp 都放在了 root 路由下，导致 workDetails 路由的地址栏也会出现 index 的一些 sp，增加一个 app id 的共享路由层，将需要 sp 的路由都放入其中

同时改用导出路由的方式使用 `use*` 等 hooks